### PR TITLE
fix/typage stepDone

### DIFF
--- a/src/Modules/Zeus/Model/Player.php
+++ b/src/Modules/Zeus/Model/Player.php
@@ -30,7 +30,7 @@ class Player
 	public int $victory = 0;
 	public int $defeat = 0;
 	public int $stepTutorial = 1;
-	public bool $stepDone = false;
+	public int $stepDone = 0;
 	public int $iUniversity = 5000;
 	public int $partNaturalSciences = 25;
 	public int $partLifeSciences = 25;


### PR DESCRIPTION
### Description : 
Fix du type stepDone dans la class Player.php qui devrait être de type int. Cela bloquait l'installation avec la commande `symfony console app:hephaistos:populate-database`